### PR TITLE
added option for players to zoom in and out (below their max zoom level)

### DIFF
--- a/LocalZoom.cs
+++ b/LocalZoom.cs
@@ -48,6 +48,12 @@ namespace LocalZoom
 
         private static AssetBundle shaderBundle;
 
+#if DEBUG
+        internal const bool DEBUG = true;
+#else
+        internal const bool DEBUG = false;
+#endif
+
         private Harmony harmony;
         private static readonly int ColorProperty = Shader.PropertyToID("_Color");
         


### PR DESCRIPTION
Added `MyCameraController::allowZoomIn` as a setting for gamemodes to allow players to zoomIn from their maximally set zoom, but not out past it.

Requires adding the dependency: `InControl`